### PR TITLE
Fix gain page rendering issue in Firefox

### DIFF
--- a/web/src/gain.ts
+++ b/web/src/gain.ts
@@ -196,7 +196,7 @@ function renderOverview(gains: Gain[]) {
   textGroup
     .append("text")
     .text((g) => formatCurrency(getInvestmentAmount(g)))
-    .attr("alignment-baseline", "hanging")
+    .attr("dominant-baseline", "hanging")
     .attr("text-anchor", "end")
     .style("fill", (g) =>
       getInvestmentAmount(g) > 0 ? z("investment") : "none"
@@ -209,7 +209,7 @@ function renderOverview(gains: Gain[]) {
   textGroup
     .append("text")
     .text((g) => formatCurrency(getGainAmount(g)))
-    .attr("alignment-baseline", "hanging")
+    .attr("dominant-baseline", "hanging")
     .attr("text-anchor", "end")
     .style("fill", (g) =>
       getGainAmount(g) > 0 ? chroma(z("gain")).darken().hex() : "none"
@@ -265,7 +265,7 @@ function renderOverview(gains: Gain[]) {
     .append("text")
     .text((g) => formatFloat(g.xirr))
     .attr("text-anchor", "end")
-    .attr("alignment-baseline", "middle")
+    .attr("dominant-baseline", "middle")
     .style("fill", (g) =>
       g.xirr < 0
         ? chroma(z("loss")).darken().hex()


### PR DESCRIPTION
Gain page is not properly getting rendered in Firefox, while works fine in chrome.

<img width="609" alt="Screenshot 2022-09-25 at 9 27 38 PM" src="https://user-images.githubusercontent.com/9396022/192152973-620db00b-2f87-45d3-9a99-e0b7f0cc41dc.png">

It appears `alignment-baseline` is not supported in Firefox, while supported in Chrome.

Using `dominant-baseline` fixed the issue. In this case using it should be fine?