### PR TITLE
fix: missing hldeger binary in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY --from=web /usr/src/paisa/web/static ./web/static
 RUN CGO_ENABLED=1 go build
 
 FROM alpine:3.18
-RUN apk --no-cache add ca-certificates ledger tzdata
+RUN apk --no-cache add ca-certificates ledger hledger tzdata
 WORKDIR /root/
 COPY --from=go /usr/src/paisa/paisa /usr/bin
 EXPOSE 7500


### PR DESCRIPTION
The hledger binary is not included in the docker image. Thus Paisa will complain of missing binary if we choose to use hleger as `ledger cli`


- [hledger in Alpine](https://pkgs.alpinelinux.org/packages?name=hledger&branch=edge&repo=&arch=&maintainer=)