### PR TITLE
Accept dollar sign as valid when default currency is USD

### DIFF
--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -452,7 +452,7 @@ func parseLedgerPrices(output string, defaultCurrency string) ([]price.Price, er
 			return nil, err
 		}
 
-		if target != defaultCurrency {
+		if target != defaultCurrency && defaultCurrency != "USD" && target != "$" {
 			continue
 		}
 


### PR DESCRIPTION
Ledger-cli will output prices using dollar-sign formatted values instead of using USD.  This results in certain price directives being ignored by Paisa when the default currency is set to "USD" which get parsed correctly when the default currency is "$"

ledger-cli only supports ASCII output so no other currency signs can be used in its output.