### PR TITLE
Needed support for more than 25 columns on import

### DIFF
--- a/src/lib/spreadsheet.ts
+++ b/src/lib/spreadsheet.ts
@@ -26,8 +26,8 @@ export function parse(file: File): Promise<Result> {
 export function asRows(result: Result): Array<Record<string, any>> {
   return _.map(result.data, (row, i) => {
     return _.chain(row)
-      .map((cell, j) => {
-        return [String.fromCharCode(65 + j), cell];
+      .map((cell, j) => {        
+        return [j>25 ? String.fromCharCode(64+j /26)+ String.fromCharCode(65+j % 26): String.fromCharCode(65+j), cell]; // A-AA-ZZZ
       })
       .concat([["index", i as any]])
       .fromPairs()
@@ -35,17 +35,18 @@ export function asRows(result: Result): Array<Record<string, any>> {
   });
 }
 
-const COLUMN_REFS = _.chain(_.range(65, 90))
-  .map((i) => String.fromCharCode(i))
-  .map((a) => [a, a])
-  .fromPairs()
-  .value();
+const COLUMN_REFS = _.chain(_.range(0, 255)) //lets support up to 255 rows of data
+   .map((j) => j>25 ? String.fromCharCode(64+j /26)+ String.fromCharCode(65+j % 26): String.fromCharCode(65+j))
+   .map((a) => [a, a])
+   .fromPairs()
+   .value();
 
 export function render(
   rows: Array<Record<string, any>>,
   template: Handlebars.TemplateDelegate,
   options: { reverse?: boolean; trim?: boolean } = {}
 ) {
+  console.log("render",rows); 
   const output: string[] = [];
   _.each(rows, (row) => {
     let rendered = template(_.assign({ ROW: row, SHEET: rows }, COLUMN_REFS));
@@ -72,6 +73,7 @@ function parseCSV(file: File): Promise<Result> {
     Papa.parse<string[]>(file, {
       skipEmptyLines: true,
       complete: function (results) {
+        console.log("results", results);
         resolve(results);
       },
       error: function (error) {

--- a/src/lib/spreadsheet.ts
+++ b/src/lib/spreadsheet.ts
@@ -45,8 +45,7 @@ export function render(
   rows: Array<Record<string, any>>,
   template: Handlebars.TemplateDelegate,
   options: { reverse?: boolean; trim?: boolean } = {}
-) {
-  console.log("render",rows); 
+) { 
   const output: string[] = [];
   _.each(rows, (row) => {
     let rendered = template(_.assign({ ROW: row, SHEET: rows }, COLUMN_REFS));
@@ -72,8 +71,7 @@ function parseCSV(file: File): Promise<Result> {
   return new Promise((resolve, reject) => {
     Papa.parse<string[]>(file, {
       skipEmptyLines: true,
-      complete: function (results) {
-        console.log("results", results);
+      complete: function (results) {        
         resolve(results);
       },
       error: function (error) {

--- a/src/routes/(app)/ledger/import/+page.svelte
+++ b/src/routes/(app)/ledger/import/+page.svelte
@@ -406,7 +406,7 @@
                 <tr>
                   <th />
                   {#each _.range(0, columnCount) as ci}
-                    <th class="has-background-light">{String.fromCharCode(65 + ci)}</th>
+                    <th class="has-background-light">{ci>25 ? String.fromCharCode(64+ci /26)+ String.fromCharCode(65+ci % 26): String.fromCharCode(65+ci)}</th>
                   {/each}
                 </tr>
               </thead>


### PR DESCRIPTION
Tried to import a file with more than 25 columns.
Yours was hardcoded so when there were more than 25 columns your ASCII mapped it to Y,Z,[,\ which is unusable by your parser.
Changed it to support up to 255 columns for now. It maps the columns as ,Y,Z,AA,AB ...
