### PR TITLE
fix(flake): update `nodejs` to v20

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
         pkgs = nixpkgs.legacyPackages.${system};
         mkdocs = mkdocs-pkgs.legacyPackages.${system};
         nodeDependencies = (pkgs.callPackage ./flake/override.nix {
-          nodejs = pkgs.nodejs-18_x;
+          nodejs = pkgs.nodejs-20_x;
         }).nodeDependencies;
       in {
         devShells.default = import ./shell.nix {


### PR DESCRIPTION
Closes https://github.com/ananthakumaran/paisa/issues/343
Fixes `error: Node.js 18.x has reached End-Of-Life and has been removed`