### PR TITLE
Handle empty response in Yahoo stock scraper

### DIFF
--- a/internal/scraper/stock/yahoo.go
+++ b/internal/scraper/stock/yahoo.go
@@ -91,6 +91,9 @@ func GetHistory(ticker string, commodityName string) ([]*price.Price, error) {
 	}
 
 	var prices []*price.Price
+	if len(response.Chart.Result) == 0 {
+		return nil, fmt.Errorf("Failed to fetch data for %s, is the ticker valid?", ticker)
+	}
 	result := response.Chart.Result[0]
 	needExchangePrice := false
 	var exchangePrice *btree.BTree


### PR DESCRIPTION
Fixes a panic that occurs when Yahoo API returns empty data for invalid tickers.

Added a simple length check before accessing `response.Chart.Result[0]` and returns a clear error message instead of crashing.

Fixes #337. 
(It took me quite some time to figure out that the issue was with updated tickers, which is why I felt this could be helpful for others too.)