### PR TITLE
fix: aarch64-linux build

### DIFF
--- a/flake/override.nix
+++ b/flake/override.nix
@@ -15,5 +15,5 @@ let
 in import ./node-package.nix {
   inherit (pkgs) fetchurl nix-gitignore stdenv lib fetchgit;
   inherit nodeEnv;
-  globalBuildInputs = [ pkgs.pkg-config pkgs.cairo pkgs.pango ];
+  globalBuildInputs = [ pkgs.pkg-config pkgs.cairo pkgs.pango pkgs.python312Packages.distutils ];
 }


### PR DESCRIPTION
Since python3.12 `distutils` is not included in the distribution. `node-gyp` needs `distutils` so it needs to be included to build the node dependencies of paisa.

https://peps.python.org/pep-0632/

I'm not sure if this is the best way of solving this issue, but I was able to compile and run Paisa on my Raspberry pi.

Fix the following issue #366