### PR TITLE
fix(nix): move CGO_ENABLED to env attribute set

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,9 @@
 
           vendorHash = "sha256-5jrxI+zSKbopGs5GmGVyqQcMHNZJbCsiFEH/LPXWxpk=";
 
-          CGO_ENABLED = 1;
+          env = {
+            CGO_ENABLED = 1;
+          };
 
           doCheck = false;
 


### PR DESCRIPTION
From the Release Notes of Nixpkgs 25.11

> buildGoModule removes the compatibility layer of CGO_ENABLED not specified via env. Specifying CGO_ENABLED directly now results in an error.