### PR TITLE
fix: nix build using node sources

### DIFF
--- a/flake/node-env.nix
+++ b/flake/node-env.nix
@@ -207,9 +207,8 @@ let
 
   # Extract the Node.js source code which is used to compile packages with
   # native bindings
-  nodeSources = runCommand "node-sources" {} ''
-    tar --no-same-owner --no-same-permissions -xf ${nodejs.src}
-    mv node-* $out
+  nodeSources = runCommand "node-sources" { } ''
+    ln -s ${pkgs.srcOnly nodejs} $out
   '';
 
   # Script that adds _integrity fields to all package.json files to prevent NPM from consulting the cache (that is empty)


### PR DESCRIPTION
This I think is needed for never node-js version in nixpkgs, because the ``src`` doesn't exist anymore