### PR TITLE
Fix Yahoo GBp stock price conversion

### DIFF
--- a/internal/scraper/stock/yahoo.go
+++ b/internal/scraper/stock/yahoo.go
@@ -83,6 +83,33 @@ func (p ExchangePrice) Less(o btree.Item) bool {
 	return p.Timestamp < (o.(ExchangePrice).Timestamp)
 }
 
+func normalizeYahooCurrency(currency string) (string, float64) {
+	switch currency {
+	case "GBp", "GBX":
+		return "GBP", 0.01
+	default:
+		return currency, 1
+	}
+}
+
+func normalizeYahooPrice(value float64, currency string) (float64, string) {
+	currency, scale := normalizeYahooCurrency(currency)
+	return value * scale, currency
+}
+
+func exchangeRateAt(exchangePrice *btree.BTree, timestamp int64) (float64, error) {
+	if exchangePrice == nil {
+		return 0, fmt.Errorf("exchange price not found for timestamp %d", timestamp)
+	}
+
+	price := utils.BTreeDescendFirstLessOrEqual(exchangePrice, ExchangePrice{Timestamp: timestamp})
+	if price.Timestamp == 0 || price.Close == 0 {
+		return 0, fmt.Errorf("exchange price not found for timestamp %d", timestamp)
+	}
+
+	return price.Close, nil
+}
+
 func GetHistory(ticker string, commodityName string) ([]*price.Price, error) {
 	log.Info("Fetching stock price history from Yahoo")
 	response, err := getTicker(ticker)
@@ -91,32 +118,65 @@ func GetHistory(ticker string, commodityName string) ([]*price.Price, error) {
 	}
 
 	var prices []*price.Price
+	if len(response.Chart.Result) == 0 {
+		return nil, fmt.Errorf("missing yahoo chart result")
+	}
+
 	result := response.Chart.Result[0]
+	if len(result.Indicators.Quote) == 0 {
+		return nil, fmt.Errorf("missing yahoo quote data")
+	}
+
+	quoteCurrency, _ := normalizeYahooCurrency(result.Meta.Currency)
 	needExchangePrice := false
 	var exchangePrice *btree.BTree
 
-	if !utils.IsCurrency(result.Meta.Currency) {
+	if !utils.IsCurrency(quoteCurrency) {
 		needExchangePrice = true
-		exchangeResponse, err := getTicker(fmt.Sprintf("%s%s=X", result.Meta.Currency, config.DefaultCurrency()))
+		exchangeResponse, err := getTicker(fmt.Sprintf("%s%s=X", quoteCurrency, config.DefaultCurrency()))
 		if err != nil {
 			return nil, err
 		}
 
+		if len(exchangeResponse.Chart.Result) == 0 {
+			return nil, fmt.Errorf("missing yahoo exchange chart result")
+		}
+
 		exchangeResult := exchangeResponse.Chart.Result[0]
+		if len(exchangeResult.Indicators.Quote) == 0 {
+			return nil, fmt.Errorf("missing yahoo exchange quote data")
+		}
 
 		exchangePrice = btree.New(2)
+		exchangeCloses := exchangeResult.Indicators.Quote[0].Close
 		for i, t := range exchangeResult.Timestamp {
-			exchangePrice.ReplaceOrInsert(ExchangePrice{Timestamp: t, Close: exchangeResult.Indicators.Quote[0].Close[i]})
+			if i >= len(exchangeCloses) {
+				return nil, fmt.Errorf("missing yahoo exchange close price for timestamp %d", t)
+			}
+
+			close := exchangeCloses[i]
+			if close == 0 {
+				continue
+			}
+			exchangePrice.ReplaceOrInsert(ExchangePrice{Timestamp: t, Close: close})
 		}
 	}
 
+	closes := result.Indicators.Quote[0].Close
 	for i, timestamp := range result.Timestamp {
+		if i >= len(closes) {
+			return nil, fmt.Errorf("missing yahoo close price for timestamp %d", timestamp)
+		}
+
 		date := time.Unix(timestamp, 0)
-		value := result.Indicators.Quote[0].Close[i]
+		value, _ := normalizeYahooPrice(closes[i], result.Meta.Currency)
 
 		if needExchangePrice {
-			exchangePrice := utils.BTreeDescendFirstLessOrEqual(exchangePrice, ExchangePrice{Timestamp: timestamp})
-			value = value * exchangePrice.Close
+			rate, err := exchangeRateAt(exchangePrice, timestamp)
+			if err != nil {
+				return nil, err
+			}
+			value = value * rate
 		}
 
 		price := price.Price{Date: date, CommodityType: config.Stock, CommodityID: ticker, CommodityName: commodityName, Value: decimal.NewFromFloat(value)}

--- a/internal/scraper/stock/yahoo_test.go
+++ b/internal/scraper/stock/yahoo_test.go
@@ -1,0 +1,63 @@
+package stock
+
+import (
+	"testing"
+
+	"github.com/google/btree"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeYahooPrice(t *testing.T) {
+	tests := []struct {
+		name             string
+		inputValue       float64
+		inputCurrency    string
+		expectedValue    float64
+		expectedCurrency string
+	}{
+		{"pounds", 140.14, "GBP", 140.14, "GBP"},
+		{"pence", 690.7, "GBp", 6.907, "GBP"},
+		{"pence alternate code", 21.5, "GBX", 0.215, "GBP"},
+		{"other currency", 10.5, "USD", 10.5, "USD"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, currency := normalizeYahooPrice(tt.inputValue, tt.inputCurrency)
+
+			assert.InDelta(t, tt.expectedValue, value, 0.000001)
+			assert.Equal(t, tt.expectedCurrency, currency)
+		})
+	}
+}
+
+func TestExchangeRateAt(t *testing.T) {
+	exchangePrice := btree.New(2)
+	exchangePrice.ReplaceOrInsert(ExchangePrice{Timestamp: 100, Close: 1.1})
+	exchangePrice.ReplaceOrInsert(ExchangePrice{Timestamp: 200, Close: 1.2})
+
+	rate, err := exchangeRateAt(exchangePrice, 250)
+
+	assert.Nil(t, err)
+	assert.InDelta(t, 1.2, rate, 0.000001)
+}
+
+func TestExchangeRateAtReturnsErrorWhenMissing(t *testing.T) {
+	exchangePrice := btree.New(2)
+	exchangePrice.ReplaceOrInsert(ExchangePrice{Timestamp: 200, Close: 1.2})
+
+	_, err := exchangeRateAt(exchangePrice, 100)
+	assert.Error(t, err)
+
+	_, err = exchangeRateAt(btree.New(2), 100)
+	assert.Error(t, err)
+}
+
+func TestExchangeRateAtReturnsErrorForZeroRate(t *testing.T) {
+	exchangePrice := btree.New(2)
+	exchangePrice.ReplaceOrInsert(ExchangePrice{Timestamp: 100, Close: 0})
+
+	_, err := exchangeRateAt(exchangePrice, 100)
+
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary
Fix Yahoo Finance stock price imports for instruments reported in pence units.

Yahoo can return chart prices with `GBp` or `GBX` currency metadata. Paisa previously treated those labels as FX currency codes, which could produce incorrect or zero imported prices. This normalizes those Yahoo pence prices to `GBP` by dividing by 100 before any default-currency conversion.

## Changes
- Normalize Yahoo `GBp`/`GBX` prices to `GBP` with a `0.01` scale.
- Use the normalized currency code when deciding whether FX conversion is needed.
- Return an error when no usable FX rate exists instead of silently using a zero-value rate.
- Add focused unit tests for pence normalization and missing/zero FX rates.

## Testing

```bash
go test ./internal/scraper/stock ./internal/utils
```