### PR TITLE
fix: correct off-by-one month shift in cash flow charts

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -816,7 +816,8 @@ export async function ajax(
         value
       )
     ) {
-      return dayjs(value);
+      // Strip the timezone offset so dayjs parses it as local midnight
+      return dayjs(value.substring(0, 19));
     }
     return value;
   });


### PR DESCRIPTION
Edit: found out that this and many other problems have been fixed by: https://github.com/matthiasdebernardini/paisa/pull/1

Fix for issue #378 
**Context**
The `/api/cash_flow` endpoint aggregates transactions into monthly buckets, labeling each bucket using the first day of the month at midnight in the user's local timezone (e.g., `2026-06-01T00:00:00+02:00` for June).

**The Bug**
When the frontend's `ajax()` JSON reviver parsed these date strings using `dayjs(value)`, the parser automatically applied timezone math to convert the timestamp to the browser's local time (or UTC). By subtracting the `+02:00` offset, the date shifted backward across the midnight boundary, resulting in the last day of the previous month (e.g., `May 31 22:00:00`). This caused the D3 charting logic to incorrectly label and plot June's data under the month of May.

**The Fix**
Modified the JSON reviver in `src/lib/utils.ts` to truncate the date string to 19 characters (`value.substring(0, 19)`) before passing it to `dayjs`. By stripping the timezone offset (leaving `2026-06-01T00:00:00`), `dayjs` is forced to parse the string strictly as local midnight, preventing the timezone shift and keeping the monthly buckets in the correct month.